### PR TITLE
v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ members = ["file_server", "response"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]
-bytes = "1"
+bytes = "1.11"
 futures-util = { version = "0.3", default-features = false }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
-hyper = { version = "1", features = ["full"] }
+hyper = { version = "1.9", features = ["full"] }
 serde_json = "1"
 serde = { version = "1.0", features = ["derive"] }
-tokio-util = "0.7.10"
-tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
+tokio = { version = "1.51", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ futures-util = { version = "0.3", default-features = false }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
 hyper = { version = "1.9", features = ["full"] }
-serde_json = "1"
+serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio-util = "0.7"
 tokio = { version = "1.51", features = ["full"] }

--- a/file_server/Cargo.toml
+++ b/file_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/response/Cargo.toml
+++ b/response/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "response"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Bump minor version. There is considerable change underneath the public API. It is possible some behaviors are different but not breaking. 